### PR TITLE
Overflow fix

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -3206,7 +3206,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
                     if (gt_i == i)
                         bcf_format_gt(f,j,s);
                     else
-                        bcf_fmt_array(s, f->n, f->type, f->p + j * f->size);
+                        bcf_fmt_array(s, f->n, f->type, f->p + (size_t)j * f->size);
                 }
                 if ( first ) kputc('.', s);
             }


### PR DESCRIPTION
When samples/ploidy/number of alt alleles is large enough, the data stored in format can go beyond 2^31-1 (even while number of genotypes is << 2^31-1,). 

j * f->size can overflow in this case...