### PR TITLE
Support gcs service accounts with GOOGLE_APPLICATION_CREDENTIALS env

### DIFF
--- a/hfile_gcs.c
+++ b/hfile_gcs.c
@@ -54,14 +54,15 @@ get_gcs_access_token()
     // Check if there is a service account env set
     const char* service_account = getenv("GOOGLE_APPLICATION_CREDENTIALS");
     if (service_account && strlen(service_account) > 0) {
-        kstring_t text = { 0, 0, NULL };
         FILE *fp = popen("gcloud auth application-default print-access-token", "r");
         if (fp) {
-            kgetline(&text, (kgets_func *) fgets, fp);
-            // setenv for later accesses to GCS_OAUTH_TOKEN
-            setenv("GCS_OAUTH_TOKEN", text.s, 1);
-            pclose(fp);
-            return text.s;
+            kstring_t text = { 0, 0, NULL };
+            if (!kgetline(&text, (kgets_func *) fgets, fp)) {
+                // setenv for later accesses to GCS_OAUTH_TOKEN
+                setenv("GCS_OAUTH_TOKEN", text.s, 1);
+                pclose(fp);
+                return text.s;
+            }
         }
     }
     return NULL;

--- a/hfile_gcs.c
+++ b/hfile_gcs.c
@@ -53,16 +53,18 @@ get_gcs_access_token()
     memset(token, 0, token_size);
     // Check if there is a service account env set
     const char* service_account = getenv("GOOGLE_APPLICATION_CREDENTIALS");
-    kstring_t text = { 0, 0, NULL };
     if (service_account && strlen(service_account) > 0) {
+        kstring_t text = { 0, 0, NULL };
         FILE *fp = popen("gcloud auth application-default print-access-token", "r");
         if (fp) {
             kgetline(&text, (kgets_func *) fgets, fp);
+            // setenv for later accesses to GCS_OAUTH_TOKEN
+            setenv("GCS_OAUTH_TOKEN", text.s, 1);
             pclose(fp);
+            return text.s;
         }
     }
-    setenv("GCS_OAUTH_TOKEN", text.s, 1);
-    return getenv("GCS_OAUTH_TOKEN");
+    return NULL;
 }
 
 static hFILE *


### PR DESCRIPTION
Currently, `GCS_OAUTH_TOKEN` and `GOOGLE_APPLICATION_CREDENTIALS`  environment variables are both required for htslib to authenticate with GCS. This PR allows for `gcloud` to authenticate when only the service account json is available via `GOOGLE_APPLICATION_CREDENTIALS` env. This will also help with the unit/integration gatk tests for GenomicsDBImport.

Tried running with travis, it is not really setup to run this fork. So, ignore the build failure.