### PR TITLE
Workaround for htslib not supporting hfile plugins when it is statically linked into GenomicsDB

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -1114,7 +1114,7 @@ static hFILE *hopen_unknown_scheme(const char *fname, const char *mode)
 }
 
 /* Returns the appropriate handler, or NULL if the string isn't an URL.  */
-static const struct hFILE_scheme_handler *find_scheme_handler(const char *s)
+const struct hFILE_scheme_handler *find_scheme_handler(const char *s)
 {
     static const struct hFILE_scheme_handler unknown_scheme =
         { hopen_unknown_scheme, hfile_always_local, "built-in", 0 };


### PR DESCRIPTION
htslib does not support extending hfile when it is statically linked into client code. 

For now, removing the static modifier from `find_scheme_handler` to allow GenomicsDB code to explicitly invoke [hfile_add_scheme_handler ](https://github.com/samtools/htslib/blob/2056490488b81169bf69beb5ac835cd22dc74a42/hfile.c#L1000) for schemes it supports linked into client code. 