### PR TITLE
[Minor] Allow for configure to work with autoconf 2.71

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,16 +7,20 @@
 *.dll.a
 *.pc.tmp
 *-uninstalled.pc
+config_vars.h
 /version.h
 
 autom4te.cache
 config.cache
+config.guess
 config.h
 config.h.in
 config.log
 config.mk
 config.status
+config.sub
 configure
+install-sh
 
 hfile_*.bundle
 hfile_*.cygdll
@@ -25,6 +29,7 @@ hfile_*.so
 
 hts-object-files
 htslib_static.mk
+htscodecs.mk
 
 cyg*.dll
 lib*.a
@@ -51,7 +56,9 @@ shlib-exports-*.txt
 /test/test-bcf-sr
 /test/test-bcf-translate
 /test/test_bgzf
+/test/test_expr
 /test/test_index
+/test/test_introspection
 /test/test_kfunc
 /test/test_kstring
 /test/test-parse-reg
@@ -66,6 +73,3 @@ shlib-exports-*.txt
 /test/*.tmp.*
 
 /TAGS
-
-aclocal.m4
-*.swp

--- a/configure.ac
+++ b/configure.ac
@@ -137,9 +137,9 @@ AC_ARG_ENABLE([s3],
                   [support Amazon AWS S3 URLs])],
   [], [enable_s3=check])
 
-test -n "$host_alias" || host_alias=unknown-`uname -s`
-AC_MSG_CHECKING([shared library type for $host_alias])
-case $host_alias in
+basic_host=${host_alias:-unknown-`uname -s`}
+AC_MSG_CHECKING([shared library type for $basic_host])
+case $basic_host in
   *-cygwin* | *-CYGWIN*)
     host_result="Cygwin DLL"
     PLATFORM=CYGWIN


### PR DESCRIPTION
Get configure to work with autoconf 2.71. Just merged the relevant code from the official master. Also got .gitignore to match that in the master as there were new files like config.guess, etc. generated.